### PR TITLE
fix non existent overload

### DIFF
--- a/FileTree/FileTree.swift
+++ b/FileTree/FileTree.swift
@@ -142,7 +142,7 @@ public class FileTree: NSBox {
     private var scrollView = NSScrollView(frame: .zero)
 
     private var autosaveName: NSTableView.AutosaveName {
-        return NSTableView.AutosaveName(rawValue: rootPath)
+        return NSTableView.AutosaveName(rootPath)
     }
 
     private func contentsOfDirectory(atPath path: String) -> [String] {


### PR DESCRIPTION
Got an error while trying to build Lona:
```
error: argument labels '(rawValue:)' do not match any available overloads
        return NSTableView.AutosaveName(rawValue: rootPath)
               ^                       ~~~~~~~~~~~~~~~~~~~~
```

I'm on macos 10.14 so that might explain it maybe 